### PR TITLE
Fix NIX_SHELL_PACKAGES with multiple -p arguments

### DIFF
--- a/nix-shell.plugin.zsh
+++ b/nix-shell.plugin.zsh
@@ -16,7 +16,7 @@ function nix-shell() {
     if [[ $key = "-p" || $key = "--packages" ]]
     then
       IN_PACKAGES=1
-      NIX_SHELL_PACKAGES+=${ARGS[2]}
+      NIX_SHELL_PACKAGES+=${NIX_SHELL_PACKAGES:+ }${ARGS[2]}
       ARGS=("${ARGS[@]:1}")
 
     # skip "--arg name value" argument


### PR DESCRIPTION
`nix-shell` allows the `-p` option to be repeated before each package:

    nix-shell -p ruby -p bundler

Currently, the `-p` handler just appends the argument after the `-p` onto the end of NIX_SHELL_PACKAGES, meaning there's no separation between them, e.g. "rubybundler". The fix is to additionally add a space if NIX_SHELL_PACKAGES is already non-empty.