### PR TITLE
Fix commands passing multiple arguments

### DIFF
--- a/scripts/buildShellShim.zsh
+++ b/scripts/buildShellShim.zsh
@@ -5,5 +5,7 @@ if [ $1 = "--rcfile" ]; then
   tmp="$(cat $1)"
   echo ${tmp%exit} > $1
   echo "zsh" >> $1
+  bash $1
+else
+  bash $@
 fi
-bash $1

--- a/scripts/buildShellShim.zsh
+++ b/scripts/buildShellShim.zsh
@@ -5,5 +5,7 @@ if [ $1 = "--rcfile" ]; then
   tmp="$(cat $1)"
   echo ${tmp%exit} > $1
   echo "zsh" >> $1
+  bash $1
+else
+  bash "$@"
 fi
-bash $1


### PR DESCRIPTION
vi running inside nix-shell won't allow me to run any commands with `:!` without complaining `bash: -c: option requires an argument`. This is because only the first option (`-c`) is passed to bash.