### PR TITLE
Quote variable in comparison zsh operator buildShellShim

### DIFF
--- a/scripts/buildShellShim.zsh
+++ b/scripts/buildShellShim.zsh
@@ -1,3 +1,4 @@
+#!/run/current-system/sw/bin/env sh
 if [ "$1" = "--rcfile" ]; then
   # the rcfile flag indicates that the --command option was used.
   # This means the shell should stay open after executing. So we remove the last line which contains 'exit'

--- a/scripts/buildShellShim.zsh
+++ b/scripts/buildShellShim.zsh
@@ -1,4 +1,4 @@
-if [ $1 = "--rcfile" ]; then
+if [ "$1" = "--rcfile" ]; then
   # the rcfile flag indicates that the --command option was used.
   # This means the shell should stay open after executing. So we remove the last line which contains 'exit'
   shift


### PR DESCRIPTION
Fixes the following error that can occur when running a command from the nix store outside of a shell.

```
/home/name/.zsh/plugins/nix-shell/scripts/buildShellShim.zsh: line 1: [: =: unary operator expected
```

The following was the original command that caused the error to appear.

```
/nix/store/q9qcsmdd1f3is074mkil94n1am7ii3zm-asciinema-2.0.1/bin/asciinema rec
```