### PR TITLE
add shebang to shim

### DIFF
--- a/scripts/buildShellShim.zsh
+++ b/scripts/buildShellShim.zsh
@@ -1,3 +1,5 @@
+#! /usr/bin/env sh
+
 if [ "$1" = "--rcfile" ]; then
   # the rcfile flag indicates that the --command option was used.
   # This means the shell should stay open after executing. So we remove the last line which contains 'exit'


### PR DESCRIPTION
I've been encountering a bug in emacs where my files could not get listed when running emacs under a nix-shell.

Turns out, emacs tries to call the function `call-process` to invoke a shell to run a git command, but when invoking the shim, it failed with error "Exec format error". It seems that such a command needs shell files to have a proper shebang to be executed appropriately.

I have added the shebang, and tested entering nix shell, things seem to be working fine elsewhere, and this fixes my issue too. Unless you have reasons not to, I believe this is an improvement.