### PR TITLE
Fix pypi2nix failing to spawn shell

### DIFF
--- a/nix-shell.plugin.zsh
+++ b/nix-shell.plugin.zsh
@@ -29,7 +29,7 @@ function nix-shell() {
     then
       PURE=1
 
-    # skip all other unary arguments 
+    # skip all other unary arguments
     elif [[ $key == "-"* ]]
     then
       IN_PACKAGES=0
@@ -52,7 +52,7 @@ function nix-shell() {
   else
     NIX_SHELL_PACKAGES="$NIX_SHELL_PACKAGES" \
     NIX_BUILD_SHELL="$NIX_SHELL_PLUGIN_DIR/scripts/buildShellShim.zsh" \
+    NIX_EXECUTING_SHELL="$SHELL" \
     command nix-shell "$@"
   fi
 }
-

--- a/scripts/buildShellShim.zsh
+++ b/scripts/buildShellShim.zsh
@@ -6,7 +6,7 @@ if [ "$1" = "--rcfile" ]; then
   shift
   tmp="$(cat $1)"
   echo ${tmp%exit} > $1
-  echo "zsh" >> $1
+  echo $NIX_EXECUTING_SHELL >> $1
   bash $1
 else
   bash "$@"


### PR DESCRIPTION
I made this change to get pypi2nix working as I experienced similar issues as in #15 
The way I managed to work around this is to introduce a new env variable NIX_EXECUTING_SHELL which (as the name says) holds the shell executable from which nix-shell was executed. It is then used by the buildShellShim as the shell. to be spawned in case of interactive invocations.

The main problem with pypi2nix was that it executes nix-shell without zsh on PATH which made the shim fail to run, it also unsets $SHELL so now with NIX_EXECUTING_SHELL empty, nothing gets executed and for such situations a bash shell stays open as a. result.

Note: Although this is meant to fix an issue with pypi2nix I suspect this to also work on other projects which use nix-shell from a clean process.