### PR TITLE
Fix home-manager installation instruction

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -53,6 +53,7 @@ Add this repository to the [`plugins` list of your configurations](https://rycee
     plugins = [
       {
         name = "zsh-nix-shell";
+        file = "nix-shell.plugin.zsh";
         src = pkgs.fetchFromGitHub {
           owner = "chisui";
           repo = "zsh-nix-shell";


### PR DESCRIPTION
Without it home-manager will make zsh try to source zsh-nix-shell.plugin.zsh