### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -33,6 +33,14 @@ ZSH_CUSTOM=$HOME/.config/oh-my-zsh
 
 After that simply install for `oh-my-zsh` as normal.
 
+## Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zsh-nix-shell` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-nix-shell_chisui" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ## Plain ZSH
 
 Clone this repository and add the following to your `~/.zshrc`.


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`zsh-nix-shell` is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!